### PR TITLE
Keep track of used space in /run by default

### DIFF
--- a/contrib/sailfish/collectd.conf
+++ b/contrib/sailfish/collectd.conf
@@ -500,6 +500,7 @@ LoadPlugin uptime
 #	Device "/dev/hda1"
 #	Device "192.168.0.2:/mnt/nfs"
 	MountPoint "/"
+	MountPoint "/run"
 	MountPoint "/tmp"
 #	FSType "ext3"
 #	IgnoreSelected false


### PR DESCRIPTION
Aliendalvik on SailfishOS tends to leak RAM by gradually using more and more space in "/run", so it makes sense to monitor /run.

Here is graph of used space from my device for example:

![storage_run](https://user-images.githubusercontent.com/3757038/34903859-27bb5f7c-f84b-11e7-9eee-c3827a1b3939.png)
