### PR TITLE
Enable config drop-ins in /etc/collectd.d, add examples

### DIFF
--- a/contrib/sailfish/collectd.conf
+++ b/contrib/sailfish/collectd.conf
@@ -2164,3 +2164,8 @@ LoadPlugin uptime
 #    </Type>
 #  </Host>
 #</Plugin>
+
+# Include system-wide drop-ins
+<Include "/etc/collectd.d">
+    Filter "*.conf"
+</Include>

--- a/contrib/sailfish/collectd.spec
+++ b/contrib/sailfish/collectd.spec
@@ -309,7 +309,7 @@ mkdir -p %{buildroot}%{_datadir}/collectd/python
 %{__install} -p -m0644 %{SOURCE11} %{buildroot}%{_datadir}/collectd/python
 
 #%{__install} -d %{buildroot}%{_sharedstatedir}/collectd/
-#%{__install} -d %{buildroot}%{_sysconfdir}/collectd.d/
+%{__install} -d %{buildroot}%{_sysconfdir}/collectd.d/
 
 
 ### Clean up docs
@@ -370,6 +370,7 @@ su nemo -c "systemctl --user daemon-reload" || systemctl-user daemon-reload || t
 %files
 #%doc AUTHORS COPYING ChangeLog README
 %config(noreplace) %{_sysconfdir}/collectd.conf
+%dir %{_sysconfdir}/collectd.d
 %{_userunitdir}/collectd.service
 #%{_userunitdir}/collectd2tmpfs.service
 #%{_userunitdir}/collectd2tmpfs.timer

--- a/contrib/sailfish/collectd.spec
+++ b/contrib/sailfish/collectd.spec
@@ -15,6 +15,7 @@ Source:		http://collectd.org/files/%{name}-%{version}.tar.bz2
 Source1:        collectd.service
 Source2:        collectd.conf
 Source3:        collectd2tmpfs.sh
+Source4:        processes.conf.example
 Source10:       connman.py
 Source11:       ofono.py
 
@@ -300,6 +301,7 @@ rm -rf %{buildroot}
 %{__install} -Dp -m0644 %{SOURCE1} %{buildroot}%{_userunitdir}/collectd.service
 %{__install} -Dp -m0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/collectd.conf
 %{__install} -Dp -m0755 %{SOURCE3} %{buildroot}%{_bindir}/collectd2tmpfs
+%{__install} -Dp -m0644 %{SOURCE4} %{buildroot}%{_sysconfdir}/collectd.d/processes.conf.example
 #%{__install} -Dp -m0644 %{_sourcedir}/collectd2tmpfs.service %{buildroot}%{_userunitdir}/collectd2tmpfs.service
 #%{__install} -Dp -m0644 %{_sourcedir}/collectd2tmpfs.timer %{buildroot}%{_userunitdir}/collectd2tmpfs.timer
 
@@ -309,7 +311,7 @@ mkdir -p %{buildroot}%{_datadir}/collectd/python
 %{__install} -p -m0644 %{SOURCE11} %{buildroot}%{_datadir}/collectd/python
 
 #%{__install} -d %{buildroot}%{_sharedstatedir}/collectd/
-%{__install} -d %{buildroot}%{_sysconfdir}/collectd.d/
+#%{__install} -d %{buildroot}%{_sysconfdir}/collectd.d/
 
 
 ### Clean up docs
@@ -371,6 +373,7 @@ su nemo -c "systemctl --user daemon-reload" || systemctl-user daemon-reload || t
 #%doc AUTHORS COPYING ChangeLog README
 %config(noreplace) %{_sysconfdir}/collectd.conf
 %dir %{_sysconfdir}/collectd.d
+%config %{_sysconfdir}/collectd.d/processes.conf.example
 %{_userunitdir}/collectd.service
 #%{_userunitdir}/collectd2tmpfs.service
 #%{_userunitdir}/collectd2tmpfs.timer

--- a/contrib/sailfish/processes.conf.example
+++ b/contrib/sailfish/processes.conf.example
@@ -1,0 +1,25 @@
+#
+# example config for process monitoring
+#
+<Plugin processes>
+	# monitor exact process name
+	#
+	#Process "lipstick"
+	#Process "systemd-journald"
+	#Process "systemd-logind"
+	#Process "systemd-udevd"
+
+	# monitor matching processes
+	# use for anything launched through Sailjail, as those apps will have multiple processes
+	# also, allows you to give a pretty name for the collection
+	#
+	#ProcessMatch "Systemdatascope"		"systemdatascope"
+	#ProcessMatch "Fernschreiber"		"harbour-fernschreiber"
+	#
+	#ProcessMatch "systemd_all"		"systemd-.*"
+	#ProcessMatch "fpd"			"(sailfish|encsfa)-fpd"
+	#
+	# Android support: monitor most android system processes
+	#ProcessMatch "com.android"		"com.android.*"
+</Plugin>
+


### PR DESCRIPTION
This updates the main config file to read stuff from `/etc/collectd.d`, and puts a usage example in there.

This way, user or system-specific monitoring configs can be created by users, and survive collectd updates (even though `%config(noreplace)` is in use, this feels cleaner).

It also opens the possibility for scripts or other apps to drop monitoring configs in a defined place without mangling the main config file.